### PR TITLE
[kern_pair] Fix cmap checks for bigrams

### DIFF
--- a/kern_pair.py
+++ b/kern_pair.py
@@ -619,7 +619,7 @@ if __name__ == "__main__":
         if options.exclude and any(c in bigram for c in options.exclude):
             continue
 
-        if any(c not in cmap for c in bigram):
+        if any(ord(c) not in cmap for c in bigram):
             continue
 
         l = create_blurred_surface_for_text_cached(bigram[0], envelope=envelope)


### PR DESCRIPTION
Checking if a character is present in cmap needs
conversion to codepoint.

Regression from 75c656f3ba3411167d29580cc5fdc14386a29a17 caused empty output from kern_pair when used with --dict option.